### PR TITLE
Add optional document-level TTL support (use case: shared event stores)

### DIFF
--- a/SimpleEventStore.AzureDocumentDb.Tests/AzureDocumentDBEventStoreInitializing.cs
+++ b/SimpleEventStore.AzureDocumentDb.Tests/AzureDocumentDBEventStoreInitializing.cs
@@ -1,10 +1,8 @@
 using System;
 using System.Linq;
-using System.Net;
 using System.Threading.Tasks;
 using Microsoft.Azure.Documents;
 using Microsoft.Azure.Documents.Client;
-using Microsoft.Azure.Documents.Linq;
 using NUnit.Framework;
 
 namespace SimpleEventStore.AzureDocumentDb.Tests
@@ -59,7 +57,7 @@ namespace SimpleEventStore.AzureDocumentDb.Tests
             var storageEngine = await StorageEngineFactory.Create(DatabaseName, o => 
             {
                 o.CollectionName = collectionName;
-                o.DefaultTimeToLive = ttl;
+                o.DefaultTimeToLiveSeconds = ttl;
             });
 
             await storageEngine.Initialise();

--- a/SimpleEventStore.AzureDocumentDb.Tests/AzureDocumentDbEventStoreAppending.cs
+++ b/SimpleEventStore.AzureDocumentDb.Tests/AzureDocumentDbEventStoreAppending.cs
@@ -1,6 +1,11 @@
-﻿using System.Threading.Tasks;
+﻿using System;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.Azure.Documents.Client;
+using Microsoft.Azure.Documents.Linq;
 using NUnit.Framework;
 using SimpleEventStore.Tests;
+using SimpleEventStore.Tests.Events;
 
 namespace SimpleEventStore.AzureDocumentDb.Tests
 {
@@ -10,6 +15,37 @@ namespace SimpleEventStore.AzureDocumentDb.Tests
         protected override Task<IStorageEngine> CreateStorageEngine()
         {
             return StorageEngineFactory.Create("AppendingTests");
+        }
+
+        [Test]
+        public async Task when_document_ttl_is_configured_then_documents_have_that_ttl_set()
+        {
+            const string DatabaseName = "AppendingTestsCosmosOnly";
+
+            var client = DocumentClientFactory.Create(DatabaseName);
+            var collectionName = "TtlTests_" + Guid.NewGuid();
+            var storageEngine = await StorageEngineFactory.Create(DatabaseName,
+                o =>
+                {
+                    o.CollectionName = collectionName;
+                    o.DefaultTimeToLiveSeconds = -1;
+                    o.DocumentTimeToLiveSeconds = 10;
+                });
+
+            await storageEngine.Initialise();
+
+            var streamId = Guid.NewGuid().ToString();
+            var store = new EventStore(storageEngine);
+            await store.AppendToStream(streamId, 0, new EventData(Guid.NewGuid(), new OrderCreated(streamId)));
+
+            var commitsLink = UriFactory.CreateDocumentCollectionUri(DatabaseName, collectionName);
+            var eventsQuery = client.CreateDocumentQuery<DocumentDbStorageEvent>(commitsLink)
+                .Where(x => x.StreamId == streamId)
+                .OrderBy(x => x.EventNumber)
+                .AsDocumentQuery();
+
+            var response = await eventsQuery.ExecuteNextAsync<DocumentDbStorageEvent>();
+            Assert.That(response.First().TimeToLiveSeconds, Is.EqualTo(10));
         }
     }
 }

--- a/SimpleEventStore.AzureDocumentDb.Tests/StorageEngineFactory.cs
+++ b/SimpleEventStore.AzureDocumentDb.Tests/StorageEngineFactory.cs
@@ -2,7 +2,6 @@
 using System.Reflection;
 using System.Threading.Tasks;
 using Microsoft.Azure.Documents;
-using Microsoft.Azure.Documents.Client;
 using Microsoft.Extensions.Configuration;
 using SimpleEventStore.Tests.Events;
 

--- a/SimpleEventStore.AzureDocumentDb/CollectionOptions.cs
+++ b/SimpleEventStore.AzureDocumentDb/CollectionOptions.cs
@@ -17,6 +17,8 @@ namespace SimpleEventStore.AzureDocumentDb
 
         public int CollectionRequestUnits { get; set; }
 
-        public int? DefaultTimeToLive { get; set; }
+        public int? DefaultTimeToLiveSeconds { get; set; }
+
+        public int? DocumentTimeToLiveSeconds { get; set; }
     }
 }

--- a/SimpleEventStore.AzureDocumentDb/DocumentDbStorageEvent.cs
+++ b/SimpleEventStore.AzureDocumentDb/DocumentDbStorageEvent.cs
@@ -7,6 +7,8 @@ namespace SimpleEventStore.AzureDocumentDb
 {
     public class DocumentDbStorageEvent
     {
+        private const string TimeToLiveCosmosDbSystemDocumentPropertyName = "ttl";
+
         [JsonProperty("id")]
         public string Id { get; set;  }
 
@@ -31,7 +33,7 @@ namespace SimpleEventStore.AzureDocumentDb
         [JsonProperty("eventNumber")]
         public int EventNumber { get; set; }
 
-        [JsonProperty(PropertyName = "ttl", NullValueHandling = NullValueHandling.Ignore)]
+        [JsonProperty(PropertyName = TimeToLiveCosmosDbSystemDocumentPropertyName, NullValueHandling = NullValueHandling.Ignore)]
         public int? TimeToLiveSeconds { get; set; }
 
         public static DocumentDbStorageEvent FromStorageEvent(StorageEvent @event, ISerializationTypeMap typeMap, int? documentTimeToLiveSeconds)
@@ -67,7 +69,7 @@ namespace SimpleEventStore.AzureDocumentDb
                 MetadataType = document.GetPropertyValue<string>("metadataType"),
                 StreamId = document.GetPropertyValue<string>("streamId"),
                 EventNumber = document.GetPropertyValue<int>("eventNumber"),
-                TimeToLiveSeconds = document.GetPropertyValue<int?>("timeToLiveSeconds")
+                TimeToLiveSeconds = document.GetPropertyValue<int?>(TimeToLiveCosmosDbSystemDocumentPropertyName)
             };
 
             return docDbEvent;

--- a/SimpleEventStore.AzureDocumentDb/DocumentDbStorageEvent.cs
+++ b/SimpleEventStore.AzureDocumentDb/DocumentDbStorageEvent.cs
@@ -1,6 +1,4 @@
 using System;
-using System.Runtime.Serialization;
-using System.Security.Cryptography.X509Certificates;
 using Microsoft.Azure.Documents;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
@@ -33,14 +31,18 @@ namespace SimpleEventStore.AzureDocumentDb
         [JsonProperty("eventNumber")]
         public int EventNumber { get; set; }
 
-        public static DocumentDbStorageEvent FromStorageEvent(StorageEvent @event, ISerializationTypeMap typeMap)
+        [JsonProperty(PropertyName = "ttl", NullValueHandling = NullValueHandling.Ignore)]
+        public int? TimeToLiveSeconds { get; set; }
+
+        public static DocumentDbStorageEvent FromStorageEvent(StorageEvent @event, ISerializationTypeMap typeMap, int? documentTimeToLiveSeconds)
         {
             var docDbEvent = new DocumentDbStorageEvent
             {
                 Id = $"{@event.StreamId}:{@event.EventNumber}",
                 EventId = @event.EventId,
                 Body = JObject.FromObject(@event.EventBody),
-                BodyType = typeMap.GetNameFromType(@event.EventBody.GetType())
+                BodyType = typeMap.GetNameFromType(@event.EventBody.GetType()),
+                TimeToLiveSeconds = documentTimeToLiveSeconds
             };
             if (@event.Metadata != null)
             {
@@ -64,7 +66,8 @@ namespace SimpleEventStore.AzureDocumentDb
                 Metadata = document.GetPropertyValue<JObject>("metadata"),
                 MetadataType = document.GetPropertyValue<string>("metadataType"),
                 StreamId = document.GetPropertyValue<string>("streamId"),
-                EventNumber = document.GetPropertyValue<int>("eventNumber")
+                EventNumber = document.GetPropertyValue<int>("eventNumber"),
+                TimeToLiveSeconds = document.GetPropertyValue<int?>("timeToLiveSeconds")
             };
 
             return docDbEvent;


### PR DESCRIPTION
Provide support for a shared event store - i.e. a need for different TTLs per stream or store consumer.

I don't like the test very much because it doesn't use a consistent level of abstraction: it uses a direct Cosmos query, the CosmosDB Storage Engine AND the Event Store interfaces all in the same test.  I think it's a symptom of:

1. This being an integration test
2. We don't expose the TTL concern higher in the stack than the CosmosDB Storage Engine (i.e. the Storage Engine interface uses dep. inversion so its interface is defined by the Event Store which has no knowledge of TTL so the TTL test cannot run purely against the Storage Engine interface).

Our task ref 1294.