### PR TITLE
Expose configuration permitting database-level throughput configuration

### DIFF
--- a/SimpleEventStore.AzureDocumentDb.Tests/AzureDocumentDbEventStoreLogging.cs
+++ b/SimpleEventStore.AzureDocumentDb.Tests/AzureDocumentDbEventStoreLogging.cs
@@ -55,7 +55,7 @@ namespace SimpleEventStore.AzureDocumentDb.Tests
                 throw new Exception($"The ConsistencyLevel value {consistencyLevel} is not supported");
             }
 
-            DocumentClient client = new DocumentClient(new Uri(documentDbUri), authKey);
+            var client = new DocumentClient(new Uri(documentDbUri), authKey);
 
             return await new AzureDocumentDbStorageEngineBuilder(client, databaseName)
                 .UseCollection(o =>

--- a/SimpleEventStore.AzureDocumentDb.Tests/SimpleEventStore.AzureDocumentDb.Tests.csproj
+++ b/SimpleEventStore.AzureDocumentDb.Tests/SimpleEventStore.AzureDocumentDb.Tests.csproj
@@ -13,12 +13,12 @@
     </Content>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Azure.DocumentDB.Core" Version="2.1.2" />
-    <PackageReference Include="Microsoft.Extensions.Configuration" Version="2.1.1" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="2.1.1" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.8.0" />
-    <PackageReference Include="NUnit" Version="3.10.1" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.10.0" />
+    <PackageReference Include="Microsoft.Azure.DocumentDB.Core" Version="2.2.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="2.2.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="2.2.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
+    <PackageReference Include="NUnit" Version="3.11.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="3.12.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\SimpleEventStore\SimpleEventStore.csproj" />

--- a/SimpleEventStore.AzureDocumentDb/AzureDocumentDbStorageEngineBuilder.cs
+++ b/SimpleEventStore.AzureDocumentDb/AzureDocumentDbStorageEngineBuilder.cs
@@ -5,11 +5,18 @@ namespace SimpleEventStore.AzureDocumentDb
 {
     public class AzureDocumentDbStorageEngineBuilder
     {
-        private readonly string databaseName;
         private readonly DocumentClient client;
         private readonly CollectionOptions collectionOptions = new CollectionOptions();
+        private readonly DatabaseOptions databaseOptions = new DatabaseOptions();
         private readonly LoggingOptions loggingOptions = new LoggingOptions();
         private ISerializationTypeMap typeMap = new DefaultSerializationTypeMap();
+
+        public AzureDocumentDbStorageEngineBuilder(DocumentClient client)
+        {
+            Guard.IsNotNull(nameof(client), client);
+
+            this.client = client;
+        }
 
         public AzureDocumentDbStorageEngineBuilder(DocumentClient client, string databaseName)
         {
@@ -17,7 +24,7 @@ namespace SimpleEventStore.AzureDocumentDb
             Guard.IsNotNullOrEmpty(nameof(databaseName), databaseName);
 
             this.client = client;
-            this.databaseName = databaseName;
+            databaseOptions.DatabaseName = databaseName;
         }
 
         public AzureDocumentDbStorageEngineBuilder UseCollection(Action<CollectionOptions> action)
@@ -25,6 +32,14 @@ namespace SimpleEventStore.AzureDocumentDb
             Guard.IsNotNull(nameof(action), action);
 
             action(collectionOptions);
+            return this;
+        }
+
+        public AzureDocumentDbStorageEngineBuilder UseDatabase(Action<DatabaseOptions> action)
+        {
+            Guard.IsNotNull(nameof(action), action);
+
+            action(databaseOptions);
             return this;
         }
 
@@ -46,7 +61,7 @@ namespace SimpleEventStore.AzureDocumentDb
 
         public IStorageEngine Build()
         {
-            var engine = new AzureDocumentDbStorageEngine(client, databaseName, collectionOptions, loggingOptions, typeMap);
+            var engine = new AzureDocumentDbStorageEngine(client, databaseOptions, collectionOptions, loggingOptions, typeMap);
             return engine;
         }
     }

--- a/SimpleEventStore.AzureDocumentDb/CollectionOptions.cs
+++ b/SimpleEventStore.AzureDocumentDb/CollectionOptions.cs
@@ -15,7 +15,7 @@ namespace SimpleEventStore.AzureDocumentDb
 
         public ConsistencyLevel ConsistencyLevel { get; set; }
 
-        public int CollectionRequestUnits { get; set; }
+        public int? CollectionRequestUnits { get; set; }
 
         public int? DefaultTimeToLiveSeconds { get; set; }
 

--- a/SimpleEventStore.AzureDocumentDb/DatabaseOptions.cs
+++ b/SimpleEventStore.AzureDocumentDb/DatabaseOptions.cs
@@ -1,0 +1,9 @@
+﻿namespace SimpleEventStore.AzureDocumentDb
+{
+    public class DatabaseOptions
+    {
+        public string DatabaseName { get; set; }
+
+        public int? DatabaseRequestUnits { get; set; }
+    }
+}

--- a/SimpleEventStore.AzureDocumentDb/SimpleEventStore.AzureDocumentDb.csproj
+++ b/SimpleEventStore.AzureDocumentDb/SimpleEventStore.AzureDocumentDb.csproj
@@ -17,7 +17,7 @@
     <None Remove="Resources\deleteStream.js" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Azure.DocumentDB.Core" Version="2.1.2" />
+    <PackageReference Include="Microsoft.Azure.DocumentDB.Core" Version="2.2.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\SimpleEventStore\SimpleEventStore.csproj" />

--- a/SimpleEventStore.Tests/SimpleEventStore.Tests.csproj
+++ b/SimpleEventStore.Tests/SimpleEventStore.Tests.csproj
@@ -11,8 +11,8 @@
     <ProjectReference Include="..\SimpleEventStore\SimpleEventStore.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.8.0" />
-    <PackageReference Include="NUnit" Version="3.10.1" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.10.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
+    <PackageReference Include="NUnit" Version="3.11.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="3.12.0" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Permit database-level throughput to be specified (as well as the existing support for collection-level throughput).

Also updates to latest downstream packages.